### PR TITLE
Fix for decorator hides parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Logo
 ### Changed
+- `quote` decorator updated
 - `quote` decorator bug fixed
 - `path_check` decorator bug fixed
+- `path_check` decorator updated
 ## [0.1] - 2023-06-10
 ### Added
 - `README.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Logo
 ### Changed
-- `quote` decorator updated
 - `quote` decorator bug fixed
 - `path_check` decorator bug fixed
-- `path_check` decorator updated
 ## [0.1] - 2023-06-10
 ### Added
 - `README.md`

--- a/nava/functions.py
+++ b/nava/functions.py
@@ -6,7 +6,9 @@ import os
 import shlex
 from functools import wraps
 
-from .params import OVERVIEW, SOUND_FILE_PLAY_ERROR, SOUND_FILE_EXIST_ERROR, SOUND_FILE_PATH_TYPE_ERROR
+from .params import OVERVIEW
+from .params import SOUND_FILE_PLAY_ERROR, SOUND_FILE_EXIST_ERROR
+from .params import SOUND_FILE_PATH_TYPE_ERROR
 from .errors import NavaBaseError
 
 

--- a/nava/functions.py
+++ b/nava/functions.py
@@ -4,6 +4,7 @@ import sys
 import subprocess
 import os
 import shlex
+from functools import wraps
 
 from .params import OVERVIEW, SOUND_FILE_PLAY_ERROR, SOUND_FILE_EXIST_ERROR, SOUND_FILE_PATH_TYPE_ERROR
 from .errors import NavaBaseError
@@ -26,6 +27,7 @@ def quote(func):
 
     :return: inner function
     """
+    @wraps(func)
     def quoter(sound_path, *args, **kwargs):
         """
         Inner function.
@@ -95,6 +97,7 @@ def path_check(func):
 
     :return: inner function
     """
+    @wraps(func)
     def path_checker(sound_path, *args, **kwargs):
         """
         Inner function.


### PR DESCRIPTION
#### Reference Issues/PRs
#16 

#### What does this implement/fix? Explain your changes.
This PR adds `wraps` decorator to the package decorators (`quote` and `path_checker`) so the input parameters are now can be seen from user perspective. 

:heavy_check_mark: Overall performance checked locally on an Ubuntu 21.04.
@sepandhaghighi please check if it is OK now in Windows' Python interpreter.